### PR TITLE
Fix: title 과 제목 템플릿이 사이즈가 같아 사이즈 수정

### DIFF
--- a/src/components/Document.js
+++ b/src/components/Document.js
@@ -132,15 +132,15 @@ export default function Document({
       let block, li, checkbox, checkText;
       switch (type) {
         case "heading1":
-          block = document.createElement("h1");
+          block = document.createElement("h2");
           block.innerHTML = "제목1";
           break;
         case "heading2":
-          block = document.createElement("h2");
+          block = document.createElement("h3");
           block.innerHTML = "제목2";
           break;
         case "heading3":
-          block = document.createElement("h3");
+          block = document.createElement("h4");
           block.innerHTML = "제목3";
           break;
         case "list":


### PR DESCRIPTION
에디터의 title 부분이 h1 으로 작업 되어있어서
템플릿의 제목 1 부분과 텍스트 사이즈가 동일하므로
제목1이 h1 에서 h2 로 수정진행
